### PR TITLE
Added ability to prefill parameters from URI

### DIFF
--- a/js/RegExr.js
+++ b/js/RegExr.js
@@ -24,3 +24,4 @@ RegExrShared.LibView = require('./views/LibView');
 RegExrShared.ExpressionModel = require('./net/ExpressionModel');
 RegExrShared.Settings = require('./Settings');
 RegExrShared.TransitionEvents = require('./events/TransitionEvents');
+RegExrShared.UriUtils = require('./utils/UriUtils');

--- a/js/documentation.js
+++ b/js/documentation.js
@@ -90,6 +90,11 @@ var library = {
 			desc:"The <b>Library</b> (this panel) includes <b>help</b> content and a <b>reference</b> that includes info on all regular expression tokens and flags."+
 				"<p>Tap a selected item in the reference to insert it into your <b>Expression</b>. Click the <span class='icon'>&#xE212;</span> beside an example to load it.</p>"+
 				"<p>The library also includes <b>example</b> patterns, searchable <b>community</b> submissions, and your saved <b>favourites</b>.</p>"
+			},
+			{
+				label: "Prefilling parameters from URI",
+				desc: "You can prefill certain parameters by passing them in on the URI. This is useful if you want to link to an arbitrary regular expression from your own site. Here's an example:" +
+				"<p><pre><code><a href='http://regexr.com?pattern=[a-z]+&flags=g&text=text_to_search' target='_blank'>http://regexr.com?pattern=[a-z]+&flags=g&text=text_to_search</a></code></pre></p>"
 			}
 		]
 		},

--- a/js/index.template.js
+++ b/js/index.template.js
@@ -53,7 +53,7 @@
 
 		RegExrShared.List.spinner = $.el(".spinner");
 
-		var querystring = RegExrShared.UriUtils.parseUri(window.location.href).queryKey;
+		var querystring = this.getUriComponents();
 
 		var docView = new RegExrShared.DocView($.el("#docview"));
 		this.docView = docView;
@@ -70,10 +70,9 @@
 
 		var initialExpression = null;
 		if (querystring.pattern) {
-			initialExpression = docView.composeExpression(querystring.pattern, querystring.flags || '');
+			initialExpression = docView.composeExpression(querystring.pattern, querystring.flags);
 		}
 		docView.setExpression(initialExpression).setState();
-
 		docView.resetHistory();
 
 		var libView = new RegExrShared.LibView($.el("#libview"), RegExrShared.Docs.content.library);
@@ -183,6 +182,15 @@
 
 	p.handleVideoClick = function (evt) {
 		this.showVideo(false);
+	};
+
+	p.getUriComponents = function () {
+		var components = {};
+		var qs = RegExrShared.UriUtils.parseUri(window.location.href).queryKey;
+		['pattern', 'flags', 'text'].forEach(function (key) {
+			components[key] = qs[key] ? decodeURIComponent(qs[key]) : ''
+		});
+		return components;
 	};
 
 	window.RegExr = s;

--- a/js/index.template.js
+++ b/js/index.template.js
@@ -53,7 +53,7 @@
 
 		RegExrShared.List.spinner = $.el(".spinner");
 
-		var querystring = this.getUriComponents();
+		var querystring = this.getRegexFromQuerystring();
 
 		var docView = new RegExrShared.DocView($.el("#docview"));
 		this.docView = docView;
@@ -184,7 +184,7 @@
 		this.showVideo(false);
 	};
 
-	p.getUriComponents = function () {
+	p.getRegexFromQuerystring = function () {
 		var components = {};
 		var qs = RegExrShared.UriUtils.parseUri(window.location.href).queryKey;
 		['pattern', 'flags', 'text'].forEach(function (key) {

--- a/js/index.template.js
+++ b/js/index.template.js
@@ -53,10 +53,13 @@
 
 		RegExrShared.List.spinner = $.el(".spinner");
 
+		var querystring = RegExrShared.UriUtils.parseUri(window.location.href).queryKey;
+
 		var docView = new RegExrShared.DocView($.el("#docview"));
 		this.docView = docView;
 		var def = $.el("#docview .default");
-		RegExrShared.DocView.DEFAULT_TEXT = (def.textContent || def.innerText).trim().replace("{{ctrl}}", $.getCtrlKey().toLowerCase());
+		var defaultText = querystring.text || (def.textContent || def.innerText).trim().replace("{{ctrl}}", $.getCtrlKey().toLowerCase());
+		RegExrShared.DocView.DEFAULT_TEXT = defaultText;
 		docView.setText(); // need to do this as well as the defer below, to keep the history clean.
 		$.defer(docView, docView.setText); // this fixes an issue with CodeMirror returning bad char positions at specific widths.
 		def.style.display = "none";
@@ -65,7 +68,12 @@
 		cheatsheet.style.display = "none";
 		RegExrShared.Docs.getItem("cheatsheet").desc = cheatsheet.innerHTML;
 
-		docView.setExpression().setState();
+		var initialExpression = null;
+		if (querystring.pattern) {
+			initialExpression = docView.composeExpression(querystring.pattern, querystring.flags || '');
+		}
+		docView.setExpression(initialExpression).setState();
+
 		docView.resetHistory();
 
 		var libView = new RegExrShared.LibView($.el("#libview"), RegExrShared.Docs.content.library);
@@ -158,7 +166,7 @@
 		var el = $.el(".video");
 		if (value !== false) {
 			var iframe = $.el("iframe", el);
-			if (!iframe.src) { iframe.src =  "//www.youtube.com/embed/fOH62XXGdLs?enablejsapi=1&autoplay=1"; }
+			if (!iframe.src) { iframe.src = "//www.youtube.com/embed/fOH62XXGdLs?enablejsapi=1&autoplay=1"; }
 			$.removeClass(el, "hidden");
 			el.addEventListener("click", this.handleVideoCloseProxy);
 			func = "playVideo";

--- a/js/utils/UriUtils.js
+++ b/js/utils/UriUtils.js
@@ -1,0 +1,39 @@
+// parseUri 1.2.2
+// (c) Steven Levithan <stevenlevithan.com>
+// MIT License
+// see: http://blog.stevenlevithan.com/archives/parseuri
+
+// adapted from https://github.com/franzenzenhofer/parseUri/blob/master/parseuri.js
+
+var UriUtils = {};
+
+UriUtils.parseUri = function (str) {
+	var o = this.options,
+		m = o.parser[o.strictMode ? "strict" : "loose"].exec(str),
+		uri = {},
+		i = 14;
+
+	while (i--) uri[o.key[i]] = m[i] || "";
+
+	uri[o.q.name] = {};
+	uri[o.key[12]].replace(o.q.parser, function ($0, $1, $2) {
+		if ($1) uri[o.q.name][$1] = $2;
+	});
+
+	return uri;
+};
+
+UriUtils.options = {
+	strictMode: true,
+	key: ["source", "protocol", "authority", "userInfo", "user", "password", "host", "port", "relative", "path", "directory", "file", "query", "anchor"],
+	q: {
+		name: "queryKey",
+		parser: /(?:^|&)([^&=]*)=?([^&]*)/g
+	},
+	parser: {
+		strict: /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,
+		loose: /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/
+	}
+};
+
+module.exports = UriUtils;


### PR DESCRIPTION
This is my first commit to this repo so apologies if I've messed something up.

This allows certain fields to be prefilled from querystring parameters.  The fields are:

- **pattern**: the regex pattern, eg. `[a-z]+`
- **flags**: the regex flags / options, eg `gi`
- **text**: the search text

These will all override the defaults already hard coded into the site. All paramters are optional. The flags parameter will only be honored if a pattern is supplied too.

Example:

http://regexr.com?pattern=[a-z]+&flags=g&text=text_to_search

Checking for possible XSS vulnerability (seems to be OK):

http://localhost:3000/?pattern=%3Cscript%3Ealert()%3C/script%3E&flags=%3Cscript%3Ealert()%3C/script%3E&text=%3Cscript%3Ealert()%3C/script%3E