### PR TITLE
adding .editorconfig - http://editorconfig.org/

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
An [.editorconfig](http://editorconfig.org/) is very nice to have. I copied this one from #144 into its own pull request so it has a better chance of getting merged