### PR TITLE
Make regexr Browserify-compatible and more easily used as a component

### DIFF
--- a/js/ExpressionHover.js
+++ b/js/ExpressionHover.js
@@ -25,6 +25,7 @@
 var Tooltip = require('./controls/Tooltip');
 var CMUtils = require('./utils/CMUtils');
 var Docs = require('./utils/Docs');
+var $ = require('./utils/Utils');
 
 var ExpressionHover = function (cm, highlighter) {
 	this.initialize(cm, highlighter);

--- a/js/RegExJS.js
+++ b/js/RegExJS.js
@@ -1,6 +1,6 @@
 var s = {};
 
-s.match = function (regex, str, callback) {
+s.match = function (regex, str, callback, workerJs) {
 	var matches = [];
 	var error = null;
 	var match = null;
@@ -11,13 +11,13 @@ s.match = function (regex, str, callback) {
 		return;
 	}
 
-	if (window.Worker) {
+	if (typeof Worker !== 'undefined' && workerJs) {
 		if (s.worker) {
 			clearTimeout(s.id);
 			s.worker.terminate();
 		}
 
-		s.worker = new Worker("js/regExWorker.template.js");
+		s.worker = new Worker(workerJs);
 
 		s.worker.onmessage = function (evt) {
 			// When the worker says its loaded start a timer. (For IE 10);

--- a/js/RegExLexer.js
+++ b/js/RegExLexer.js
@@ -99,14 +99,15 @@ p.parse = function (str, parseType) {
 	var groups = [], i = 0, l = str.length;
 	var o, c, token, prev = null, charset = null, unquantifiable = RegExLexer.UNQUANTIFIABLE;
 	var charTypes = RegExLexer.CHAR_TYPES;
-	var closeIndex = str.lastIndexOf("/");
+	var closeIndex = parseType === 'all' ? str.lastIndexOf("/") : Infinity;
 
 	while (i < l) {
 		c = str[i];
 
 		token = {i: i, l: 1, prev: prev};
 
-		if (parseType === 'all' && (i == 0 || i >= closeIndex)) {
+		if (parseType === 'flags' ||
+				(parseType === 'all' && (i == 0 || i >= closeIndex))) {
 			this.parseFlag(str, token);
 		} else if (c == "(" && !charset) {
 			this.parseGroup(str, token);
@@ -159,7 +160,7 @@ p.parse = function (str, parseType) {
 			// this may be the start of a range, but we'll need to validate after the next token.
 			token.type = "range";
 		} else {
-			this.parseChar(str, token, charset);
+			this.parseChar(str, token, charset, parseType !== 'all');
 		}
 
 		if (prev) {
@@ -217,10 +218,10 @@ p.parseFlag = function (str, token) {
 	token.clear = true;
 };
 
-p.parseChar = function (str, token, charset) {
+p.parseChar = function (str, token, charset, allowSlash) {
 	var c = str[token.i];
 	token.type = (!charset && RegExLexer.CHAR_TYPES[c]) || "char";
-	if (!charset && c == "/") {
+	if (!charset && c == "/" && !allowSlash) {
 		token.err = "fwdslash";
 	}
 	if (token.type == "char") {

--- a/js/RegExLexer.js
+++ b/js/RegExLexer.js
@@ -79,7 +79,15 @@ p.token = null;
 p.errors = null;
 p.captureGroups = null;
 
-p.parse = function (str) {
+/**
+ * Parse a regular expression
+ * @param {String} str   string to parse
+ * @param {String} parseType  type of parsing to do ('pattern', 'flags', or 'all')
+ *                       			Optional: defaults to all
+ */
+p.parse = function (str, parseType) {
+	parseType = parseType || 'all';
+
 	if (str == this.string) {
 		return this.token;
 	}
@@ -98,7 +106,7 @@ p.parse = function (str) {
 
 		token = {i: i, l: 1, prev: prev};
 
-		if (i == 0 || i >= closeIndex) {
+		if (parseType === 'all' && (i == 0 || i >= closeIndex)) {
 			this.parseFlag(str, token);
 		} else if (c == "(" && !charset) {
 			this.parseGroup(str, token);

--- a/js/SourceHighlighter.js
+++ b/js/SourceHighlighter.js
@@ -45,7 +45,7 @@ p.draw = function (matches, activeMatch, selectedMatch) {
 	if (!matches || !matches.length) {
 		return;
 	}
-	
+
 
 	var cm = this.cm;
 	var doc = cm.getDoc();
@@ -55,11 +55,11 @@ p.draw = function (matches, activeMatch, selectedMatch) {
 	// find the range of the visible text:
 	var scroll = cm.getScrollInfo();
 	var top = cm.indexFromPos(cm.coordsChar({
-		left: 0,
+		left: scroll.left,
 		top: scroll.top
 	}, "local"));
 	var bottom = cm.indexFromPos(cm.coordsChar({
-		left: scroll.clientWidth,
+		left: scroll.left + scroll.clientWidth,
 		top: scroll.top + scroll.clientHeight
 	}, "local"));
 
@@ -79,32 +79,32 @@ p.draw = function (matches, activeMatch, selectedMatch) {
 		var selected = (match === selectedMatch);
 
 		if (active || selected) { ctx.globalAlpha = 0.45; }
-		
+
 		var startRect = cm.charCoords(startPos, "local");
 		var endRect = cm.charCoords(endPos, "local");
 
 		if (startRect.bottom == endRect.bottom) {
-			this.drawHighlight(ctx, startRect.left, startRect.top, endRect.right, endRect.bottom, scroll.top);
+			this.drawHighlight(ctx, startRect.left, startRect.top, endRect.right, endRect.bottom, scroll.left, scroll.top);
 		} else {
 			var lw = cm.getScrollInfo().width;
 			var lh = cm.defaultTextHeight();
 			// render first line:
-			this.drawHighlight(ctx, startRect.left, startRect.top, lw - 2, startRect.bottom, scroll.top, false, true); // startRect.top+lh
+			this.drawHighlight(ctx, startRect.left, startRect.top, lw - 2, startRect.bottom, scroll.left, scroll.top, false, true); // startRect.top+lh
 			// render lines in between:
 			var y = startRect.top;
 			while ((y += lh) < endRect.top - 1) { // the -1 is due to fractional issues on FF
-				this.drawHighlight(ctx, 0, y, lw - 2, y + startRect.bottom - startRect.top, scroll.top, true, true); // lh
+				this.drawHighlight(ctx, 0, y, lw - 2, y + startRect.bottom - startRect.top, scroll.left, scroll.top, true, true); // lh
 			}
 			// render last line:
-			this.drawHighlight(ctx, 0, endRect.top, endRect.right, endRect.bottom, scroll.top, true);
+			this.drawHighlight(ctx, 0, endRect.top, endRect.right, endRect.bottom, scroll.left, scroll.top, true);
 			// CMUtils.getEOLPos(this.sourceCM, startPos);
 		}
-		
+
 		if (active || selected) { ctx.globalAlpha = 1; }
 	}
 };
 
-p.drawHighlight = function (ctx, left, top, right, bottom, scrollY, startCap, endCap) {
+p.drawHighlight = function (ctx, left, top, right, bottom, scrollX, scrollY, startCap, endCap) {
 	var capW = 4;
 
 	if (right < 0 || left + 1 >= right) {
@@ -126,16 +126,16 @@ p.drawHighlight = function (ctx, left, top, right, bottom, scrollY, startCap, en
 	var a = ctx.globalAlpha;
 	if (startCap) {
 		ctx.globalAlpha = a * 0.5;
-		ctx.fillRect(left + 1 | 0, top - scrollY, capW + 1, bottom - top);
+		ctx.fillRect((left + 1 || 0) - scrollX, top - scrollY, capW + 1, bottom - top);
 		left += capW;
 	}
 	if (endCap) {
 		ctx.globalAlpha = a * 0.5;
-		ctx.fillRect(right - capW - 1 | 0, top - scrollY, capW + 1, bottom - top);
+		ctx.fillRect((right - capW - 1 || 0) - scrollY, top - scrollY, capW + 1, bottom - top);
 		right -= capW;
 	}
 	ctx.globalAlpha = a;
-	ctx.fillRect(left + 1, top - scrollY, right - left - 1, bottom - top);
+	ctx.fillRect(left + 1 - scrollX, top - scrollY, right - left - 1, bottom - top);
 };
 
 p.clear = function () {

--- a/js/controls/Tooltip.js
+++ b/js/controls/Tooltip.js
@@ -23,6 +23,7 @@
  */
 
 var EventDispatcher = require('../events/EventDispatcher');
+var $ = require('../utils/Utils');
 
 var Tooltip = function (target, content, config) {
 	this.initialize(target, content, config);

--- a/js/controls/Tooltip.js
+++ b/js/controls/Tooltip.js
@@ -114,15 +114,15 @@ p.show = function (content, rect) {
 
 		el.style.pointerEvents = this.config.mouseEnabled !== false;
 
-		el.className = "tooltip" + ((this.config && this.config.className) ? " " + this.config.className : "");
-		tip.className = "tooltip-tip";
+		el.className = "regexr-tooltip" + ((this.config && this.config.className) ? " " + this.config.className : "");
+		tip.className = "regexr-tooltip-tip";
 		document.body.appendChild(this.element);
 		document.body.appendChild(this.tip);
 
 		var _this = this;
 		setTimeout(function () { // needs to be delayed for transition to work
-			el.className += " tooltip-visible";
-			tip.className += " tooltip-visible";
+			el.className += " regexr-tooltip-visible";
+			tip.className += " regexr-tooltip-visible";
 		}, 0);
 	}
 

--- a/js/utils/Docs.js
+++ b/js/utils/Docs.js
@@ -25,6 +25,7 @@
 var documentation = require('../documentation');
 var TextUtils = require('./TextUtils');
 var Utils = require('./Utils');
+var $ = Utils;
 
 var Docs = {};
 

--- a/js/views/DocView.js
+++ b/js/views/DocView.js
@@ -117,7 +117,7 @@ p.initialize = function (element) {
 
 	Docs.content.library.desc = $.el(".lib .content").innerHTML;
 	window.onbeforeunload = $.bind(this, this.handleUnload);
-	
+
 	this.buildUI(element);
 
 	// Set the default state.
@@ -169,7 +169,7 @@ p.buildUI = function (el) {
 		readOnly: true,
 		lineWrapping: true
 	});
-	
+
 	this.toolsResults = $.el(".tools.results");
 
 	// Flags
@@ -337,7 +337,7 @@ p.showTools = function (value) {
 	}
 	this.deferUpdate();
 	this.resize();
-	
+
 	// this ensures the Text highlights update correctly when the Tools show / hide:
 	this.sourceCM.refresh();
 };
@@ -352,10 +352,10 @@ p.setTool = function(tool) {
 	this.tool = tool;
 	el = $.el(".tools.title .button."+tool);
 	$.addClass(el,"active");
-	
+
 	$.removeClass(this.element, /tool-/);
 	$.addClass(this.element, "tool-"+tool);
-	
+
 	this.updateTool();
 };
 
@@ -421,14 +421,14 @@ p.setupUndo = function() {
 		_this.addHistory(srcCM);
 	});
 	srcCM.setOption("undoDepth", this.maxHistoryDepth);
-	
+
 	expCM.getDoc().on("historyAdded", function () {
 		_this.addHistory(expCM);
 	});
 	expCM.setOption("undoDepth", this.maxHistoryDepth);
-	
+
 	// NOTE: undo / redo is set up for the replace / list CMs in createToolCM.
-	
+
 	window.addEventListener("keydown", $.bind(this, this.handleKeyDown));
 };
 
@@ -507,7 +507,7 @@ p.sourceMouseMove = function (evt) {
 	if (rect) {
 		rect.right = rect.left = evt.clientX;
 	}
-	 
+
 	this.sourceTooltip.show(Docs.forMatch(this.hoverMatch), rect);
 };
 
@@ -544,7 +544,7 @@ p.update = function () {
 	this.expressionHighlighter.draw(this.exprLexer.parse(expr));
 	this.expressionHover.token = this.exprLexer.token;
 	matches.length = 0;
-	
+
 	// this is only ok if we are very confident we will not have false errors in the lexer.
 	// used primarily to handle fwdslash errors.
 	if (this.exprLexer.errors.length || !regex) {
@@ -570,15 +570,15 @@ p.update = function () {
 		if (ExpressionModel.id) {
 			BrowserHistory.go($.createID(ExpressionModel.id));
 		}
-	});
+	}, "js/regExWorker.template.js");
 };
 
 p.getRegEx = function(global) {
 	var regex, o = this.decomposeExpression(this.expressionCM.getValue());
-	
+
 	if (global === true && o.flags.indexOf("g") === -1) { o.flags += "g"; }
 	else if (global === false) { o.flags = o.flags.replace("g",""); }
-	
+
 	try {
 		regex = new RegExp(o.pattern, o.flags);
 	} catch (e) {}
@@ -588,18 +588,18 @@ p.getRegEx = function(global) {
 p.updateTool = function (source, regex) {
 	var oldMatch = this.selectedMatch;
 	var match = this.selectedMatch = null;
-	
+
 	if (!this.toolsEnabled) { return; }
 	source = source||this.sourceCM.getValue();
 	var result = "", toolsCM = this.getToolCM(), err = this.error;
 	if (toolsCM) {
 		var str = toolsCM.getValue();
-		
+
 		var token = this.toolsLexer.parse(str, this.exprLexer.captureGroups);
 		toolsCM.highlighter.cm = toolsCM;
 		toolsCM.highlighter.draw(token);
 		toolsCM.hover.token = token;
-		
+
 		if (err) {
 			result = "EXPRESSION ERROR";
 		} else if (this.toolsLexer.errors.length === 0) {
@@ -632,13 +632,13 @@ p.updateTool = function (source, regex) {
 	} else if (this.tool == "details") {
 		var cm = this.sourceCM;
 		match = this.getMatchAt(cm.indexFromPos(cm.getCursor()), true);
-		
+
 		if (match) {
-			result += "<h1><b>Match #"+match.num+"</b>"+ 
-				"  <b>Length:</b> "+(match.end-match.index+1)+ 
+			result += "<h1><b>Match #"+match.num+"</b>"+
+				"  <b>Length:</b> "+(match.end-match.index+1)+
 				"  <b>Range:</b> "+match.index+"-"+match.end+"</h1>"+
 				"<p>"+TextUtils.htmlSafe(match[0])+"</p>";
-				
+
 			for (var i=1; i<match.length; i++) {
 				var group = match[i];
 				result += "<h1><b>Group #"+i+"</b>"+
@@ -646,16 +646,16 @@ p.updateTool = function (source, regex) {
 					"<p>"+TextUtils.htmlSafe(group||"")+"</p>";
 			}
 		}
-		
+
 		result += "<p class='info'>click a <span class='match'>match</span> above for details</p>";
 		$.el(".content",this.toolsResults).innerHTML = "<code><pre>"+result+"</code></pre>";
-		
+
 	} else if (this.tool == "explain") {
 		var token = this.exprLexer.token, expr = this.expressionCM.getValue();
 		result = Explain.forExpression(expr, token, this.expressionHighlighter);
 		$.empty($.el(".content",this.toolsResults)).appendChild(result);
 	}
-	
+
 	if (match !== oldMatch) {
 		this.selectedMatch = match;
 		$.defer(this, this.drawSourceHighlights, "draw");
@@ -796,17 +796,17 @@ p.createToolCM = function(target, content) {
 	}, "100%", "auto");
 	cm.setValue(content || "");
 	cm.on("change", $.bind(this, this.deferUpdate));
-	
+
 	cm.highlighter = new ExpressionHighlighter(cm);
 	cm.hover = new ExpressionHover(cm, cm.highlighter);
-	
+
 	// undo / redo:
 	var _this = this;
 	cm.getDoc().on("historyAdded", function () {
 		_this.addToolsHistory();
 	});
 	cm.setOption("undoDepth", this.maxHistoryDepth);
-	
+
 	return cm;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "regexr-site",
-  "version": "12.1.0",
+  "version": "2.1.0",
   "license": "MIT",
-  "repository": "git+https://github.com/pxpeterxu/regexr.git",
+  "repository": "http://github.com/gskinner/regexr/regexr.git",
   "devDependencies": {
     "browser-sync": "^2.10.0",
     "browserify": "^10.2.6",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "RegExr",
-  "version": "2.1.0",
+  "name": "regexr",
+  "version": "12.1.0",
   "license": "MIT",
-  "repository": "http://github.com/gskinner/regexr/regexr.git",
+  "repository": "git+https://github.com/pxpeterxu/regexr.git",
   "devDependencies": {
     "browser-sync": "^2.10.0",
     "browserify": "^10.2.6",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "regexr",
+  "name": "regexr-site",
   "version": "12.1.0",
   "license": "MIT",
   "repository": "git+https://github.com/pxpeterxu/regexr.git",

--- a/scss/tooltips.scss
+++ b/scss/tooltips.scss
@@ -1,4 +1,4 @@
-.tooltip {
+.regexr-tooltip {
 	font-size: 0.875rem;
 	font-family: $monospace;
 	max-width: 30em;
@@ -35,19 +35,19 @@
     }
 }
 
-.tooltip-tip {
+.regexr-tooltip-tip {
 	width: 19px;
 	height: 10px;
 	background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAAKCAYAAABWiWWfAAAANUlEQVR42o3MMQ0AAAzDsCEp1jFvKfjIF/mSSC+fQhVQoQpIkIIAOQiQgwA5CJCDADkIkIMD+gmc/LP+8KQAAAAASUVORK5CYII=);
 }
 
-.tooltip, .tooltip-tip {
+.regexr-tooltip, .regexr-tooltip-tip {
 	opacity: 0.0;
 	@include vendor-prefix(transition, opacity $default-transition-duration);
 	position: fixed;
 	z-index: $z-index-tip;
 }
 
-.tooltip-visible {
+.regexr-tooltip-visible {
 	opacity: 1.0;
 }


### PR DESCRIPTION
Thanks again, Grant, for all the hard work and making this project open-source!

This pull request is to make the code in RegExr reusable as components in other sites. I really wanted to reuse some of the components of the regex pattern editor on WrapAPI (https://wrapapi.com), which is now [published on npm](https://www.npmjs.com/package/react-regexr) and that required a few changes:

* Change the package name in package.json to `regexr-site` (if you ever are willing to publish this to npm)
* Change instances where we rely on `$` to be the global `Utils` to instead be explicitly required so that the package works well with Browserify/Webpack
* Prefix CSS classes so that they're less likely to conflict
* Allow using regexr with a non-word-wrapped Codemirror editor (by also taking into account `scrollLeft`)
* Allow using regexr without a web worker if it isn't specified by falling back to the main-thread logic in `RegExJS.js`

Currently, I've been maintaining this as a fork, but I thought it'd be great to give back and merge them in.