### PR TITLE
Fix mysqli error when deploying

### DIFF
--- a/server/core/API.php
+++ b/server/core/API.php
@@ -86,7 +86,7 @@ class API {
 
     function connect() {
         $this->db = new \core\DB();
-        $this->db->connect(DB_HOST, DB_USER_NAME, DB_PASSWORD, DB_NAME, DB_PORT, DB_SOCK);
+        $this->db->connect(DB_HOST, DB_USER_NAME, DB_PASSWORD, DB_NAME);
     }
 
     function result($data, $time=null) {


### PR DESCRIPTION
When deploying without this fix, the website would show a mysqli connection error on PHP 7.4. Removing unnecessary arguments fixes this issue.