### PR TITLE
Trim regex before pasting

### DIFF
--- a/dev/src/views/Expression.js
+++ b/dev/src/views/Expression.js
@@ -223,7 +223,7 @@ export default class Expression extends EventDispatcher {
 		// catches pasting full expressions in.
 		// TODO: will need to be updated to work with other delimeters
 		this._deferUpdate();
-		let str = evt.text[0];
+		let str = evt.text[0].trim();
 		if (str.length < 3 || !str.match(/^\/.+[^\\]\/[a-z]*$/ig) || evt.from.ch !== 1 || evt.to.ch != 1 + evt.removed[0].length) {
 			// not pasting a full expression.
 			return;


### PR DESCRIPTION
When pasting a full regex expression into the expression bar, I often have some trailing whitespace on one end or another, causing it to not be detected as a regular expression when pasting. This PR trims that whitespace so it will be detected. Regular strings that do not match as regular expressions will not be trimmed.