### PR TITLE
Allow empty text/expression query string

### DIFF
--- a/dev/src/RegExr.js
+++ b/dev/src/RegExr.js
@@ -60,13 +60,14 @@ export default class RegExr extends EventDispatcher {
 		this._savedHash = null;
 
 		let params = Utils.getUrlParams();
+		console.log(params);
 		if (Utils.isLocal && params.id) {
 			Server.load(params.id).then((o) => this.state = o);
 			params = {};
 		}
 		if (params.engine) { this.flavor.value = params.engine; }
-		if (params.expression) { this.expression.value = params.expression; }
-		if (params.text) { this.text.value = params.text; }
+		if (params.expression !== undefined) { this.expression.value = params.expression; }
+		if (params.text !== undefined) { this.text.value = params.text; }
 		if (params.tool) { this.tools.value = {id:params.tool, input:params.input}; }
 
 		window.onbeforeunload = (e) => this.unsaved ? "You have unsaved changes." : null;

--- a/dev/src/views/Expression.js
+++ b/dev/src/views/Expression.js
@@ -223,7 +223,7 @@ export default class Expression extends EventDispatcher {
 		// catches pasting full expressions in.
 		// TODO: will need to be updated to work with other delimeters
 		this._deferUpdate();
-		let str = evt.text[0];
+		let str = evt.text[0].trim();
 		if (str.length < 3 || !str.match(/^\/.+[^\\]\/[a-z]*$/ig) || evt.from.ch !== 1 || evt.to.ch != 1 + evt.removed[0].length) {
 			// not pasting a full expression.
 			return;

--- a/dev/src/views/Expression.js
+++ b/dev/src/views/Expression.js
@@ -43,7 +43,7 @@ export default class Expression extends EventDispatcher {
 	}
 	
 	set value(expression) {
-		let regex = Utils.decomposeRegEx(expression || Expression.DEFAULT_EXPRESSION, this.delim);
+		let regex = Utils.decomposeRegEx(expression ?? Expression.DEFAULT_EXPRESSION, this.delim);
 		this.pattern = regex.source;
 		this.flags = regex.flags;
 	}

--- a/dev/src/views/Text.js
+++ b/dev/src/views/Text.js
@@ -47,7 +47,7 @@ export default class Text extends EventDispatcher {
 	}
 	
 	set value(val) {
-		this.editor.setValue(val || this.defaultText);
+		this.editor.setValue(val ?? this.defaultText);
 	}
 	
 	get value() {


### PR DESCRIPTION
Leaving an empty value for an expression or text query string will make that value actually be empty (previously would just use the default value)