### PR TITLE
Only warn about missing features for mainstream modern browsers

### DIFF
--- a/dev/src/ExpressionLexer.js
+++ b/dev/src/ExpressionLexer.js
@@ -184,12 +184,14 @@ export default class ExpressionLexer {
 
 	addJSWarnings(token) {
 		if (token.error) { return; }
-		if ((token.type === "neglookbehind" || token.type === "poslookbehind") ||
-			(token.type === "sticky" || token.type === "unicode" || token.type == "dotall") ||
-			(token.type === "unicodecat" || token.type === "unicodescript") ||
-			(token.type === "namedgroup")
-			) {
-				token.error = {id: "jsfuture", warning:true};
+
+		// https://caniuse.com/js-regexp-lookbehind
+		// - lookbehind missing in iOS Safari (16.3) as of 2023-02-16
+		if ([
+			"neglookbehind",
+			"poslookbehind"
+		].includes(token.type)) {
+			token.error = { id: "jsfuture", warning: true };
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/gskinner/regexr/issues/489:

> [IE is officially dead](https://death-to-ie11.com/), so maybe these warnings should be removed for features supported in all current browsers, such as [the `u` flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode).

**Methodology**: check caniuse for each feature, only including mainstream modern browsers (no IE, no Opera Mini, and ignoring the various Chinese browsers, which are all based on mainstream modern browser engines).

**Sources**:

* `neglookbehind`, `poslookbehind`: https://caniuse.com/js-regexp-lookbehind
* `sticky`: https://caniuse.com/mdn-javascript_builtins_regexp_sticky
* `unicode`: https://caniuse.com/mdn-javascript_builtins_regexp_unicode
* `dotall`: https://caniuse.com/mdn-javascript_builtins_regexp_dotall
* `unicodecat`, `unicodescript`: https://caniuse.com/mdn-javascript_builtins_regexp_property_escapes
* `namedgroup`: https://caniuse.com/mdn-javascript_builtins_regexp_named_capture_groups

**Results**: only `neglookbehind` and `poslookbehind` are missing, thanks to iOS Safari. Presumably upcoming features like [RegExp `v` flag](https://github.com/tc39/proposal-regexp-v-flag) will also lack comprehensive support for a while after they're officially added to the spec.