### PR TITLE
Get correct pattern when URL contains query params

### DIFF
--- a/index.php
+++ b/index.php
@@ -30,7 +30,8 @@ try {
 
 $pattern = 'null';
 $result = [];
-$success = preg_match("/([a-z0-9]+)\$/", $_SERVER['REQUEST_URI'], $result);
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$success = preg_match("/([a-z0-9]+)\$/", $path, $result);
 if ($success == true) {
     $stringId = $result[0];
     $id = convertFromURL($stringId);


### PR DESCRIPTION
Hi,
The saved pattern does not load, when URL contains query parameters eg:

https://regexr.com/3bfsi?fbclid=IwAR0sxFWLaea8c
<img width="469" alt="image" src="https://github.com/gskinner/regexr/assets/9026680/3a874082-7143-4ae5-86c5-ebcabe25c1ce">

vs

https://regexr.com/3bfsi
<img width="756" alt="image" src="https://github.com/gskinner/regexr/assets/9026680/b21295c5-24f8-439d-aae8-9f74bda8a90b">

I discovered this by sharing a regexr's URL on Facebook, that adds this parameter. Other services may also add certain parameters, so this is a PR with fix.